### PR TITLE
Re-re-re-add GPG_TTY but to the `gpg` call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,11 @@ jobs:
 
       - name: Sign checksums
         run: |
-          gpg -vvv --batch --yes --detach-sign --armor checksums.txt \
+          GPG_TTY=$(tty) gpg -vvv --batch --yes --detach-sign --armor \
             --local-user "${{ secrets.GPG_FINGERPRINT }}" \
             --output checksums.txt.sig \
             --passphrase "${{ secrets.GPG_PASSPHRASE }}" \
-            --pinentry-mode loopback
+            --pinentry-mode loopback checksums.txt
 
       - name: Create release
         env:


### PR DESCRIPTION
Turns out `--pinentry loopback` necessitates `GPG_TTY`. 🤦