### PR TITLE
Moved PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+---
+name: Pull request
+about: If you have a pull request to fix a bug or add a feature
+---
+
+## Pull request checklist
+
+Please check if your PR fulfills the following requirements:
+
+- [ ] You have read the contributing guide
+- [ ] Tests for the changes have been added
+- [ ] The documentation has been reviewed and updated as needed
+
+## What is the current behavior?
+
+_Please describe the current behavior that you are modifying, and link its a relevant issue_
+
+Issue Number: _Add the issue number this PR address here._
+
+## What is the new behavior?
+
+-
+-
+-
+
+## Does this introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+**If yes, please describe...**
+
+## Other relevant information
+
+_e.g. does this PR require another PR to be merged first?_


### PR DESCRIPTION
Move the PR Template to `.github` root. Was not triggering in a template directory with just one template.