### PR TITLE
Add missing \ to release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}"
+            --repo "${{ github.repository }}" \
             --generate-notes
 
       - name: Upload artifacts


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

The release will not be created and error due to a missing `\` in a multiline command.

## What is the new behavior?

The GitHub action should now successfully create a GitHub release. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other relevant information

N/A